### PR TITLE
feature/fetchNftsViaAlchemy

### DIFF
--- a/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
+++ b/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AA06E34E293E5B5500EA87EA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA06E34D293E5B5500EA87EA /* Preview Assets.xcassets */; };
 		AA622D2E293E91C900F89657 /* NftListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA622D2D293E91C900F89657 /* NftListViewModel.swift */; };
 		AA622D30293E920F00F89657 /* NftList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA622D2F293E920F00F89657 /* NftList.swift */; };
+		AAD8836629463E6200727A99 /* AlchemyNfts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD8836529463E6200727A99 /* AlchemyNfts.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +24,7 @@
 		AA06E34D293E5B5500EA87EA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AA622D2D293E91C900F89657 /* NftListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftListViewModel.swift; sourceTree = "<group>"; };
 		AA622D2F293E920F00F89657 /* NftList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftList.swift; sourceTree = "<group>"; };
+		AAD8836529463E6200727A99 /* AlchemyNfts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlchemyNfts.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +60,7 @@
 				AA06E346293E5B5400EA87EA /* AlchemyDemoApp.swift */,
 				AA06E348293E5B5400EA87EA /* NftListView.swift */,
 				AA622D2D293E91C900F89657 /* NftListViewModel.swift */,
+				AAD8836529463E6200727A99 /* AlchemyNfts.swift */,
 				AA622D2F293E920F00F89657 /* NftList.swift */,
 				AA06E34A293E5B5500EA87EA /* Assets.xcassets */,
 				AA06E34C293E5B5500EA87EA /* Preview Content */,
@@ -146,6 +149,7 @@
 				AA622D30293E920F00F89657 /* NftList.swift in Sources */,
 				AA06E349293E5B5400EA87EA /* NftListView.swift in Sources */,
 				AA622D2E293E91C900F89657 /* NftListViewModel.swift in Sources */,
+				AAD8836629463E6200727A99 /* AlchemyNfts.swift in Sources */,
 				AA06E347293E5B5400EA87EA /* AlchemyDemoApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
+++ b/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -263,6 +264,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
@@ -1,0 +1,32 @@
+//
+//  AlchemyNfts.swift
+//  alchemy-demo-ios
+//
+//  Created by Amaury WEI on 11.12.22.
+//
+
+import Foundation
+
+/// Returned data when performing a `/getNfts` request on the Alchemy API
+struct AlchemyNfts: Codable {
+    var ownedNfts: [AlchemyNft]
+    var totalCount: Int
+    var blockHash: String
+}
+
+/// Represents a single owned NFT item.
+/// - Warning: More fields exist in the retrieved JSON data, only the relevant ones for this demo have been declared
+struct AlchemyNft: Codable {
+    var contract: AlchemyContract
+    var metadata: AlchemyMetadata
+}
+
+struct AlchemyContract: Codable {
+    var address: String
+}
+
+struct AlchemyMetadata: Codable {
+    var description: String?
+    var image: String?
+    var name: String?
+}

--- a/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
@@ -7,14 +7,22 @@
 
 import Foundation
 
+/// Standardized struct for a single NFT
+struct Nft {
+    /// Smart contract address of the NFT
+    var address: String
+    /// URL to the NFT
+    var image: URL
+}
+
 /// Storage for a list of NFTs
 struct NftList {
     /// NFTs are stored as an array of Strings
-    private(set) var nfts: [String] = [String]()
+    private(set) var nfts: [Nft] = [Nft]()
     
     /// Set the list of NFTs stored inside the list
     /// - Parameter nfts: NFTs to store inside the list
-    mutating func setNfts(_ nfts: [String]) {
+    mutating func setNfts(_ nfts: [Nft]) {
         self.nfts = nfts
     }
 }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -12,8 +12,8 @@ struct NftListView: View {
     /// Stored NFTs list
     @ObservedObject var nftList = NftListViewModel()
     
-    /// Example of an ETH wallet address owning multiple NFTs
-    static let defaultEthAddress = "0xbe6b5dBBA3d59Fa6a0C3d5bB787aa5D5ee4F535d"
+    /// Example of an ETH wallet address owning multiple NFTs (Vitalik BUTERIN's address)
+    static let defaultEthAddress = "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
     
     /// ETH wallet address (modified by the ethAddressForm)
     @State private var ethAddress: String = defaultEthAddress
@@ -70,7 +70,15 @@ struct NftListView: View {
     func fetchNfts() {
         // Dismiss the keyboard of the ETH Address TextField
         ethAddressIsFocused = false
-        nftList.fetchNfts(ethWalletAddress: ethAddress)
+        
+        // Create a dedicated Task as fetchNfts() is asynchronous
+        Task {
+            do {
+                try await nftList.fetchNfts(ethWalletAddress: ethAddress)
+            } catch let error {
+                print("ERROR: Failed to fetch NFTs: ", error)
+            }
+        }
     }
     
 }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -24,7 +24,7 @@ class NftListViewModel: ObservableObject {
     @Published private var model = NftList()
     
     /// Stored list of NFTs
-    var nfts: [String] {
+    var nfts: [Nft] {
         return model.nfts
     }
     
@@ -38,13 +38,39 @@ class NftListViewModel: ObservableObject {
         guard let nftsRequestUrl = URL(string: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)/getNFTs?owner=\(ethWalletAddress)") else { throw FetchNftsError.invalidUrl }
         
         // Perform the HTTPS request
-        print("Performing HTTPS GET request: ", nftsRequestUrl.absoluteString)
+        print("INFO: Performing HTTPS GET request: ", nftsRequestUrl.absoluteString)
         let nftsRequest = URLRequest(url: nftsRequestUrl)
         let (data, response) = try await URLSession.shared.data(for: nftsRequest)
         guard (response as? HTTPURLResponse)?.statusCode == HTTP_STATUS_CODE_OK else { throw FetchNftsError.requestFailed }
         
         // Decode the NFTs using Alchemy structs
         let decodedNfts = try JSONDecoder().decode(AlchemyNfts.self, from: data)
-        print("NFTs retrieved: ", decodedNfts.totalCount)
+        print("INFO: NFTs retrieved: ", decodedNfts.totalCount)
+        
+        // Convert those Alchemy-based NFTs into custom NFT structures
+        let standardizedNfts = standardizeNfts(alchemyNfts: decodedNfts)
+        print("INFO: Valid NFTs: ", standardizedNfts.count)
+        
+        // Update the internal model (from the main thread)
+        DispatchQueue.main.async {
+            self.model.setNfts(standardizedNfts)
+        }
+    }
+    
+    /// Convert Alchemy NFTs to standardize NFTs.
+    /// NFTs with an invalid or missing image metadata will be discarded
+    /// - Parameter alchemyNfts: Decoded set of NFTs retrieved from the Alchemy API
+    /// - Returns: Array of standardized `Nft` struct
+    func standardizeNfts(alchemyNfts: AlchemyNfts) -> [Nft] {
+        var nfts = [Nft]()
+        for nft in alchemyNfts.ownedNfts {
+            // Filter the NFTs without any metadata or invalid URLs (most likely errors)
+            if let image = nft.metadata.image {
+                if let imageUrl = URL(string: image) {
+                    nfts.append(Nft(address: nft.contract.address, image: imageUrl))
+                }
+            }
+        }
+        return nfts
     }
 }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -10,6 +10,16 @@ import SwiftUI
 /// ViewModel to store a list of NFTs
 class NftListViewModel: ObservableObject {
     
+    /// Custom Errors thrown by `fetchNfts()`
+    enum FetchNftsError: Error {
+        case invalidUrl
+        case requestFailed
+    }
+    
+    /// Replace with your own ALCHEMY_API_KEY
+    private let ALCHEMY_API_KEY = "your_key_here"
+    private let HTTP_STATUS_CODE_OK: Int = 200
+    
     /// Storage of the list of NFTs
     @Published private var model = NftList()
     
@@ -22,8 +32,19 @@ class NftListViewModel: ObservableObject {
     
     /// Fetch the NFTs from an ETH wallet using the Alchemy API
     /// - Parameter ethWalletAddress: ETH wallet address to fetch the NFTs from
-    func fetchNfts(ethWalletAddress: String) {
-        //! TODO: Fetch the NFTs here using Alchemy API
-        print("TODO: Fetch the NFTs from \(ethWalletAddress)")
+    /// - Throws: Errors of type `FetchNftsError`or `DecodingError`
+    func fetchNfts(ethWalletAddress: String) async throws {
+        // Create the proper URL using the private Alchemy API key and the specified ETH address
+        guard let nftsRequestUrl = URL(string: "https://eth-goerli.g.alchemy.com/v2/\(ALCHEMY_API_KEY)/getNFTs?owner=\(ethWalletAddress)") else { throw FetchNftsError.invalidUrl }
+        
+        // Perform the HTTPS request
+        print("Performing HTTPS GET request: ", nftsRequestUrl.absoluteString)
+        let nftsRequest = URLRequest(url: nftsRequestUrl)
+        let (data, response) = try await URLSession.shared.data(for: nftsRequest)
+        guard (response as? HTTPURLResponse)?.statusCode == HTTP_STATUS_CODE_OK else { throw FetchNftsError.requestFailed }
+        
+        // Decode the NFTs using Alchemy structs
+        let decodedNfts = try JSONDecoder().decode(AlchemyNfts.self, from: data)
+        print("NFTs retrieved: ", decodedNfts.totalCount)
     }
 }


### PR DESCRIPTION
# Fetch NFTs via the [Alchemy](https://www.alchemy.com/) API

## New features

- Update the model and view-model to use a standardized `Nft` custom structure
- Implement the `fetchNfts()` function
  - Perform HTTP GET request `/getNfts` to the [Alchemy](https://www.alchemy.com/) API 
  - Decode the data response and filter invalid NFTs
  - Update the view-model with retrieved NFTs