### PR TITLE
feature/displayNftsAsList

### DIFF
--- a/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
+++ b/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AA06E34E293E5B5500EA87EA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA06E34D293E5B5500EA87EA /* Preview Assets.xcassets */; };
 		AA622D2E293E91C900F89657 /* NftListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA622D2D293E91C900F89657 /* NftListViewModel.swift */; };
 		AA622D30293E920F00F89657 /* NftList.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA622D2F293E920F00F89657 /* NftList.swift */; };
+		AAA68CED294660D00038E932 /* NftView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA68CEC294660D00038E932 /* NftView.swift */; };
 		AAD8836629463E6200727A99 /* AlchemyNfts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD8836529463E6200727A99 /* AlchemyNfts.swift */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,7 @@
 		AA06E34D293E5B5500EA87EA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AA622D2D293E91C900F89657 /* NftListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftListViewModel.swift; sourceTree = "<group>"; };
 		AA622D2F293E920F00F89657 /* NftList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftList.swift; sourceTree = "<group>"; };
+		AAA68CEC294660D00038E932 /* NftView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NftView.swift; sourceTree = "<group>"; };
 		AAD8836529463E6200727A99 /* AlchemyNfts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlchemyNfts.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -59,6 +61,7 @@
 			children = (
 				AA06E346293E5B5400EA87EA /* AlchemyDemoApp.swift */,
 				AA06E348293E5B5400EA87EA /* NftListView.swift */,
+				AAA68CEC294660D00038E932 /* NftView.swift */,
 				AA622D2D293E91C900F89657 /* NftListViewModel.swift */,
 				AAD8836529463E6200727A99 /* AlchemyNfts.swift */,
 				AA622D2F293E920F00F89657 /* NftList.swift */,
@@ -151,6 +154,7 @@
 				AA622D2E293E91C900F89657 /* NftListViewModel.swift in Sources */,
 				AAD8836629463E6200727A99 /* AlchemyNfts.swift in Sources */,
 				AA06E347293E5B5400EA87EA /* AlchemyDemoApp.swift in Sources */,
+				AAA68CED294660D00038E932 /* NftView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/xcshareddata/xcschemes/alchemy-demo-ios.xcscheme
+++ b/alchemy-demo-ios/alchemy-demo-ios.xcodeproj/xcshareddata/xcschemes/alchemy-demo-ios.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA06E342293E5B5400EA87EA"
+               BuildableName = "alchemy-demo-ios.app"
+               BlueprintName = "alchemy-demo-ios"
+               ReferencedContainer = "container:alchemy-demo-ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA06E342293E5B5400EA87EA"
+            BuildableName = "alchemy-demo-ios.app"
+            BlueprintName = "alchemy-demo-ios"
+            ReferencedContainer = "container:alchemy-demo-ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA06E342293E5B5400EA87EA"
+            BuildableName = "alchemy-demo-ios.app"
+            BlueprintName = "alchemy-demo-ios"
+            ReferencedContainer = "container:alchemy-demo-ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
@@ -18,12 +18,17 @@ struct AlchemyNfts: Codable {
 /// - Warning: More fields exist in the retrieved JSON data, only the relevant ones for this demo have been declared
 struct AlchemyNft: Codable {
     var contract: AlchemyContract
+    var id: AlchemyId
     var metadata: AlchemyMetadata
     var error: String?
 }
 
 struct AlchemyContract: Codable {
     var address: String
+}
+
+struct AlchemyId: Codable {
+    var tokenId: String
 }
 
 struct AlchemyMetadata: Codable {

--- a/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/AlchemyNfts.swift
@@ -19,6 +19,7 @@ struct AlchemyNfts: Codable {
 struct AlchemyNft: Codable {
     var contract: AlchemyContract
     var metadata: AlchemyMetadata
+    var error: String?
 }
 
 struct AlchemyContract: Codable {

--- a/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Standardized struct for a single NFT
 struct Nft: Identifiable {
-    var id: String { address }
+    var id: Int
     /// Smart contract address of the NFT
     var address: String
     /// URL to the NFT

--- a/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
@@ -16,6 +16,11 @@ struct Nft: Identifiable {
     var tokenId: String
     /// URL to the NFT
     var image: URL
+    
+    /// Token ID of the NFT in the smart contract
+    var tokenIdAsUInt: UInt64? {
+        UInt64(self.tokenId.dropFirst(2), radix: 16)
+    }
 }
 
 /// Storage for a list of NFTs

--- a/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
@@ -11,7 +11,9 @@ import Foundation
 struct Nft: Identifiable {
     var id: Int
     /// Smart contract address of the NFT
-    var address: String
+    var contractAddress: String
+    /// Token ID of the NFT in the smart contract
+    var tokenId: String
     /// URL to the NFT
     var image: URL
 }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftList.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Standardized struct for a single NFT
-struct Nft {
+struct Nft: Identifiable {
+    var id: String { address }
     /// Smart contract address of the NFT
     var address: String
     /// URL to the NFT

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -59,7 +59,7 @@ struct NftListView: View {
                 nftsList
             } header: {
                 if nftList.nfts.count > 0 {
-                    Text("Fetched NFTs")
+                    Text("Fetched NFTs: \(nftList.nfts.count)")
                 }
             }
         }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// Core view of the application
 struct NftListView: View {
+    @Environment(\.openURL) var openURL
+    
     /// Stored NFTs list
     @ObservedObject var nftList = NftListViewModel()
     
@@ -49,8 +51,14 @@ struct NftListView: View {
                 Text("Enter an ETH wallet address to fetch its NFTs")
             }
             
-            Section{
+            Section {
                 fetchButton
+            }
+            
+            Section {
+                nftsList
+            } header: {
+                Text("Fetched NFTs")
             }
         }
     }
@@ -62,6 +70,17 @@ struct NftListView: View {
                 Spacer()
                 Text("Fetch NFTs")
                 Spacer()
+            }
+        }
+    }
+    
+    /// List of fetched NFTs
+    var nftsList: some View {
+        List{
+            ForEach(nftList.nfts) { nft in
+                NftView(nft: nft).onTapGesture {
+                    openURL(nft.image)
+                }
             }
         }
     }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -14,7 +14,7 @@ struct NftListView: View {
     /// Stored NFTs list
     @ObservedObject var nftList = NftListViewModel()
     
-    /// Example of an ETH wallet address owning multiple NFTs 
+    /// Example of an ETH wallet address owning multiple NFTs
     static let defaultEthAddress = "0x928c2909847B884ba5Dd473568De6382b028F7b8"
     
     /// ETH wallet address (modified by the ethAddressForm)
@@ -58,7 +58,9 @@ struct NftListView: View {
             Section {
                 nftsList
             } header: {
-                Text("Fetched NFTs")
+                if nftList.nfts.count > 0 {
+                    Text("Fetched NFTs")
+                }
             }
         }
     }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -14,8 +14,8 @@ struct NftListView: View {
     /// Stored NFTs list
     @ObservedObject var nftList = NftListViewModel()
     
-    /// Example of an ETH wallet address owning multiple NFTs (Vitalik BUTERIN's address)
-    static let defaultEthAddress = "0xab5801a7d398351b8be11c439e05c5b3259aec9b"
+    /// Example of an ETH wallet address owning multiple NFTs 
+    static let defaultEthAddress = "0x928c2909847B884ba5Dd473568De6382b028F7b8"
     
     /// ETH wallet address (modified by the ethAddressForm)
     @State private var ethAddress: String = defaultEthAddress

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -93,7 +93,7 @@ class NftListViewModel: ObservableObject {
             // Filter the NFTs without any metadata or invalid URLs (most likely errors)
             if let image = nft.metadata.image {
                 if let imageUrl = URL(string: image) {
-                    nfts.append(Nft(id: index, address: nft.contract.address, image: imageUrl))
+                    nfts.append(Nft(id: index, contractAddress: nft.contract.address, tokenId: nft.id.tokenId, image: imageUrl))
                 }
             }
         }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -66,19 +66,8 @@ class NftListViewModel: ObservableObject {
             if let error = nft.error, error != "" {
                 return false
             }
-            
-            // Remove NFTs which have invalid URLs
-            guard nft.metadata.image != nil else {
-                return false
-            }
-            guard URL(string: nft.metadata.image!) != nil else {
-                return false
-            }
-            
             return true
         }
-        
-        // Remove duplicate NFTs
         
         return AlchemyNfts(ownedNfts: filteredNfts, totalCount: filteredNfts.count, blockHash: alchemyNfts.blockHash)
     }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -89,11 +89,11 @@ class NftListViewModel: ObservableObject {
     /// - Returns: Array of standardized `Nft` struct
     func standardizeNfts(alchemyNfts: AlchemyNfts) -> [Nft] {
         var nfts = [Nft]()
-        for nft in alchemyNfts.ownedNfts {
+        for (index, nft) in alchemyNfts.ownedNfts.enumerated() {
             // Filter the NFTs without any metadata or invalid URLs (most likely errors)
             if let image = nft.metadata.image {
                 if let imageUrl = URL(string: image) {
-                    nfts.append(Nft(address: nft.contract.address, image: imageUrl))
+                    nfts.append(Nft(id: index, address: nft.contract.address, image: imageUrl))
                 }
             }
         }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
@@ -22,7 +22,7 @@ struct NftView_Previews: PreviewProvider {
     static var previews: some View {
         let exampleAddress = "0x8a6f2ee949ce6c98bfe053a5d8057d01e695d808"
         let exampleImageUrl = URL(string: "https://images.unsplash.com/photo-1518717758536-85ae29035b6d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80")
-        let exampleNft = Nft(address: exampleAddress, image: exampleImageUrl!)
+        let exampleNft = Nft(id: 0, address: exampleAddress, image: exampleImageUrl!)
         
         NftView(nft: exampleNft)
     }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
@@ -13,16 +13,25 @@ struct NftView: View {
     let nft: Nft
     
     var body: some View {
-        Text(nft.address.replacingOccurrences(of: "0x", with: ""))
-            .font(.footnote)
+        let stripped_nft_address = nft.contractAddress.replacingOccurrences(of: "0x", with: "")
+        VStack{
+            Text("\(nft.id): \(stripped_nft_address)")
+                .font(.footnote)
+        }
     }
 }
 
 struct NftView_Previews: PreviewProvider {
     static var previews: some View {
-        let exampleAddress = "0x8a6f2ee949ce6c98bfe053a5d8057d01e695d808"
+        let exampleContractAddress = "0x8a6f2ee949ce6c98bfe053a5d8057d01e695d808"
+        let exampleTokenId = "0x000000000000000000000000000000000000000000013"
         let exampleImageUrl = URL(string: "https://images.unsplash.com/photo-1518717758536-85ae29035b6d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80")
-        let exampleNft = Nft(id: 0, address: exampleAddress, image: exampleImageUrl!)
+        let exampleNft = Nft(
+            id: 0,
+            contractAddress: exampleContractAddress,
+            tokenId: exampleTokenId,
+            image: exampleImageUrl!
+        )
         
         NftView(nft: exampleNft)
     }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
@@ -13,11 +13,37 @@ struct NftView: View {
     let nft: Nft
     
     var body: some View {
-        let stripped_nft_address = nft.contractAddress.replacingOccurrences(of: "0x", with: "")
-        VStack{
-            Text("\(nft.id): \(stripped_nft_address)")
-                .font(.footnote)
+        VStack(alignment: .leading) {
+            contractAddressHeading
+            contractAddressFormatted
+            
+            tokenIdHeading
+            tokenIdFormatted
         }
+    }
+    
+    var contractAddressHeading: some View {
+        Text("Contract Address (hex)")
+            .foregroundColor(.gray)
+            .font(.footnote)
+    }
+    
+    var contractAddressFormatted: some View {
+        Text(nft.contractAddress.dropFirst(2))
+            .font(.footnote)
+    }
+    
+    var tokenIdHeading: some View {
+        Text("Token ID (decimal)")
+            .foregroundColor(.gray)
+            .font(.footnote)
+    }
+    
+    var tokenIdFormatted: some View {
+        guard nft.tokenIdAsUInt != nil else {
+            return Text("Unknown").font(.footnote)
+        }
+        return Text(String(nft.tokenIdAsUInt!)).font(.footnote)
     }
 }
 

--- a/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftView.swift
@@ -1,0 +1,29 @@
+//
+//  NftView.swift
+//  alchemy-demo-ios
+//
+//  Created by Amaury WEI on 11.12.22.
+//
+
+import SwiftUI
+
+/// View to represent an NFT as a single Text line
+struct NftView: View {
+    /// NFT to represent in the View
+    let nft: Nft
+    
+    var body: some View {
+        Text(nft.address.replacingOccurrences(of: "0x", with: ""))
+            .font(.footnote)
+    }
+}
+
+struct NftView_Previews: PreviewProvider {
+    static var previews: some View {
+        let exampleAddress = "0x8a6f2ee949ce6c98bfe053a5d8057d01e695d808"
+        let exampleImageUrl = URL(string: "https://images.unsplash.com/photo-1518717758536-85ae29035b6d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80")
+        let exampleNft = Nft(address: exampleAddress, image: exampleImageUrl!)
+        
+        NftView(nft: exampleNft)
+    }
+}


### PR DESCRIPTION
# Display fetched NFTs as list

## New features

- Filter invalid NFTs (_i.e._ which have an `error` field)
- Display fetched NFTs as a scrollable list
  - Contract address (hexademical)
  - Token ID (decimal)

## Screenshots

<p float="left">
<img src="https://user-images.githubusercontent.com/47786924/208300153-4da1ac6a-c71d-4e7d-9aff-d88ef71378d0.png" alt="Launch screen (no NFTs)" width="400"/>
<img src="https://user-images.githubusercontent.com/47786924/208300164-c3c3daaf-d1e1-4009-9978-9609a9bd21b1.png" alt="List of fetched NFTs" width="400"/>
</p>