### PR TITLE
feature/addUiAlertsForFeedback

### DIFF
--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -124,6 +124,9 @@ struct NftListView: View {
         // Start progress view
         nftsFetchingInProgress = true
         
+        // Clear all NFTs currently stored
+        nftList.clearNfts()
+        
         // Create a dedicated Task as fetchNfts() is asynchronous
         Task {
             do {

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -60,7 +60,7 @@ struct NftListView: View {
             
             Section {
                 fetchButton
-            }
+            }.disabled(ethAddress.isEmpty)
             
             Section {
                 nftsList

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListView.swift
@@ -24,12 +24,18 @@ struct NftListView: View {
     
     /// Indicates that a NFTs fetch request is being
     @State private var nftsFetchingInProgress = false
+    
     /// Set to true to show the NFTs fetching failed alert
     @State private var nftsFetchingFailed = false
     /// Alert message in case the NFTs cannot be fetched
     @State private var nftsFetchingFailedMessage: String = ""
     /// Alert title in case the NFTs cannot be fetched
     let failedFetchingAlertTitle: String = "Failed to fetch NFTs"
+    
+    /// Set to true to show the NFT's URL opening failed alert
+    @State private var nftUrlOpeningFailed = false
+    /// Alert title in case the NFT's URL cannot be opened
+    let failedNftUrlOpeningAlertTitle: String = "Failed to open the NFT's URL"
     
     var body: some View {
         VStack {
@@ -87,7 +93,7 @@ struct NftListView: View {
                 Spacer()
             }
         }.alert(failedFetchingAlertTitle, isPresented: $nftsFetchingFailed) {
-            Button("Dismiss", role: .cancel) {
+            Button("OK", role: .cancel) {
                 nftsFetchingFailed = false
             }
         } message: {
@@ -110,7 +116,17 @@ struct NftListView: View {
         List{
             ForEach(nftList.nfts) { nft in
                 NftView(nft: nft).onTapGesture {
-                    openURL(nft.image)
+                    openURL(nft.image) { accepted in
+                        if accepted { return }
+                        print("Failed to open URL associated with NFT \(nft.id)")
+                        nftUrlOpeningFailed = true
+                    }
+                }.alert(failedNftUrlOpeningAlertTitle, isPresented: $nftUrlOpeningFailed) {
+                    Button("OK", role: .cancel) {
+                        nftUrlOpeningFailed = false
+                    }
+                } message: {
+                    Text("This NFT has an invalid or unsupported URL associated to it.")
                 }
             }
         }

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -65,7 +65,7 @@ class NftListViewModel: ObservableObject {
     
     /// Filter invalid NFTs obtained from the Alchemy API.
     /// NFTs considered invalid: `error` field is present, invalid image URL
-    func filterInvalidNfts(alchemyNfts: AlchemyNfts) -> AlchemyNfts {
+    private func filterInvalidNfts(alchemyNfts: AlchemyNfts) -> AlchemyNfts {
         let filteredNfts = alchemyNfts.ownedNfts.filter { nft in
             // Remove NFTs which have an `error` field
             if let error = nft.error, error != "" {
@@ -81,7 +81,7 @@ class NftListViewModel: ObservableObject {
     /// NFTs with an invalid or missing image metadata will be discarded
     /// - Parameter alchemyNfts: Decoded set of NFTs retrieved from the Alchemy API
     /// - Returns: Array of standardized `Nft` struct
-    func standardizeNfts(alchemyNfts: AlchemyNfts) -> [Nft] {
+    private func standardizeNfts(alchemyNfts: AlchemyNfts) -> [Nft] {
         var nfts = [Nft]()
         for (index, nft) in alchemyNfts.ownedNfts.enumerated() {
             // Filter the NFTs without any metadata or invalid URLs (most likely errors)

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -7,15 +7,15 @@
 
 import SwiftUI
 
+/// Custom Errors thrown by `fetchNfts()`
+enum FetchNftsError: Error {
+    case dummyAlchemyApiKey
+    case invalidUrl
+    case requestFailed
+}
+
 /// ViewModel to store a list of NFTs
 class NftListViewModel: ObservableObject {
-    
-    /// Custom Errors thrown by `fetchNfts()`
-    enum FetchNftsError: Error {
-        case invalidUrl
-        case requestFailed
-    }
-    
     /// Replace with your own ALCHEMY_API_KEY
     private let ALCHEMY_API_KEY = "your_key_here"
     private let HTTP_STATUS_CODE_OK: Int = 200
@@ -34,6 +34,11 @@ class NftListViewModel: ObservableObject {
     /// - Parameter ethWalletAddress: ETH wallet address to fetch the NFTs from
     /// - Throws: Errors of type `FetchNftsError`or `DecodingError`
     func fetchNfts(ethWalletAddress: String) async throws {
+        // Making sure you have updated the `ALCHEMY_API`KEY` with your own
+        guard ALCHEMY_API_KEY != "your_key_here" else {
+            throw FetchNftsError.dummyAlchemyApiKey
+        }
+        
         // Create the proper URL using the private Alchemy API key and the specified ETH address
         guard let nftsRequestUrl = URL(string: "https://eth-mainnet.g.alchemy.com/v2/\(ALCHEMY_API_KEY)/getNFTs?owner=\(ethWalletAddress)&excludeFilters[SPAM,AIRDROPS]") else { throw FetchNftsError.invalidUrl }
         

--- a/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
+++ b/alchemy-demo-ios/alchemy-demo-ios/NftListViewModel.swift
@@ -63,6 +63,11 @@ class NftListViewModel: ObservableObject {
         }
     }
     
+    /// Clear all stored NFTs
+    func clearNfts() {
+        model.setNfts([])
+    }
+    
     /// Filter invalid NFTs obtained from the Alchemy API.
     /// NFTs considered invalid: `error` field is present, invalid image URL
     private func filterInvalidNfts(alchemyNfts: AlchemyNfts) -> AlchemyNfts {


### PR DESCRIPTION
# Add UI alerts for user feedback

## New core features

- Show an alert when the `ALCHEMY_API_KEY` has not been updated
- Show an alert when the HTTP request fails
- Show an alert when the NFT's URL cannot be opened by iOS

## Additional new features

- Add visual feedback when the HTTP request is pending (spinner wheel)
- Clear all NFTs when performing a new fetch request (fetch button click)
- Disable the fetch button when the ETH address text field is empty

## Screenshots

<p float="left">
<img src="https://user-images.githubusercontent.com/47786924/208305039-f647d398-409e-423a-bc51-2e4c03abdfcd.png" alt="Spining Progress View" width="400"/>
<img src="https://user-images.githubusercontent.com/47786924/208305041-a2b331dc-ed93-4536-acfd-b019ce6752d9.png" alt="Invalid NFT URL alert box" width="400"/>
</p>
